### PR TITLE
[codex] Fix constraint violation logging

### DIFF
--- a/robot_payload_id/optimization/nevergrad_augmented_lagrangian.py
+++ b/robot_payload_id/optimization/nevergrad_augmented_lagrangian.py
@@ -5,6 +5,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import nevergrad as ng
 import numpy as np
+import wandb
 
 from pydrake.all import (
     AugmentedLagrangianNonsmooth,
@@ -13,8 +14,6 @@ from pydrake.all import (
 )
 from tqdm import tqdm
 from wandb.sdk.wandb_summary import SummarySubDict
-
-import wandb
 
 # Create a cache for multiprocessing
 _MAX_NUM_WORKERS = 64
@@ -250,36 +249,35 @@ class NevergradAugmentedLagrangian:
         constraint_types = [name.split("_")[0] for name in constraint_names]
 
         # Assumes that constraint name has the form "name_..."
-        constraint_type_violations_map = dict(
-            zip(list(set(constraint_types)), [0] * len(constraint_types))
-        )
+        constraint_type_violations_map = {
+            constraint_type: 0 for constraint_type in constraint_types
+        }
 
         # See Drake augmented_lagrangian.cc::EvalAugmentedLagrangian for context
         lag_idx = 0
         is_equality_mask = nonsmooth_al.is_equality()
-        for constraint, constraint_type, is_equality in zip(
-            constraints, constraint_types, is_equality_mask
-        ):
+        for constraint, constraint_type in zip(constraints, constraint_types):
             if isinstance(constraint, BoundingBoxConstraint):
                 # No residuals exist for these bounds
                 continue
 
-            constraint_tol = (
-                self._equality_constraint_tol
-                if is_equality
-                else self._inequality_constraint_tol
-            )
             for i in range(constraint.num_constraints()):
                 lb = constraint.lower_bound()[i]
                 ub = constraint.upper_bound()[i]
                 if lb == ub:
                     # Constraint adds one Lagrange multiplier
+                    constraint_tol = self._equality_constraint_tol
+                    assert is_equality_mask[lag_idx], "Expected equality constraint."
                     if constraint_residue[lag_idx] ** 2 > constraint_tol:
                         constraint_type_violations_map[constraint_type] += 1
                     lag_idx += 1
                 else:
                     # Constraint adds 0 to 2 Lagrange multipliers
+                    constraint_tol = self._inequality_constraint_tol
                     if not np.isinf(lb):
+                        assert not is_equality_mask[
+                            lag_idx
+                        ], "Expected inequality constraint."
                         if (
                             np.maximum(-constraint_residue[lag_idx], 0) ** 2
                             > constraint_tol
@@ -288,6 +286,9 @@ class NevergradAugmentedLagrangian:
                         lag_idx += 1
 
                     if not np.isinf(ub):
+                        assert not is_equality_mask[
+                            lag_idx
+                        ], "Expected inequality constraint."
                         if (
                             np.maximum(-constraint_residue[lag_idx], 0) ** 2
                             > constraint_tol
@@ -299,6 +300,10 @@ class NevergradAugmentedLagrangian:
             logging.warning(
                 "Skipping to log constraint violations for decision variable bounds."
             )
+        else:
+            assert lag_idx == len(
+                is_equality_mask
+            ), "Constraint metadata did not match augmented Lagrangian size."
 
         num_constraint_violations = sum(list(constraint_type_violations_map.values()))
         wandb.log(

--- a/robot_payload_id/optimization/nevergrad_util.py
+++ b/robot_payload_id/optimization/nevergrad_util.py
@@ -2,7 +2,6 @@ from pathlib import Path
 from typing import List, Union
 
 import nevergrad as ng
-
 import wandb
 
 

--- a/robot_payload_id/optimization/optimal_experiment_design_b_spline.py
+++ b/robot_payload_id/optimization/optimal_experiment_design_b_spline.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Any, Dict, Optional, Union
 
 import numpy as np
+import wandb
 import yaml
 
 from pydrake.all import (
@@ -19,8 +20,6 @@ from pydrake.all import (
     ModelInstanceIndex,
     MultibodyPlant,
 )
-
-import wandb
 
 from robot_payload_id.data import (
     compute_base_param_mapping,

--- a/robot_payload_id/optimization/optimal_experiment_design_base.py
+++ b/robot_payload_id/optimization/optimal_experiment_design_base.py
@@ -5,11 +5,10 @@ from pathlib import Path
 from typing import Any, Optional, Tuple
 
 import numpy as np
+import wandb
 
 from numpy import ndarray
 from pydrake.all import MakeVectorVariable, ModelInstanceIndex, MultibodyPlant
-
-import wandb
 
 from robot_payload_id.data import (
     extract_symbolic_data_matrix,

--- a/robot_payload_id/optimization/optimal_experiment_design_fourier.py
+++ b/robot_payload_id/optimization/optimal_experiment_design_fourier.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, Optional, Union
 
 import nevergrad as ng
 import numpy as np
+import wandb
 import yaml
 
 from pydrake.all import (
@@ -25,8 +26,6 @@ from pydrake.all import (
     Simulator,
     SnoptSolver,
 )
-
-import wandb
 
 from robot_payload_id.data import (
     compute_autodiff_joint_data_from_fourier_series_traj_params1,

--- a/robot_payload_id/utils/dataclasses.py
+++ b/robot_payload_id/utils/dataclasses.py
@@ -6,6 +6,7 @@ from typing import List, Optional, Tuple, Union
 
 import numpy as np
 import pydrake.symbolic as sym
+import wandb
 
 from pydrake.all import (
     BsplineBasis,
@@ -19,8 +20,6 @@ from pydrake.all import (
     TrajectorySource,
     VectorLogSink,
 )
-
-import wandb
 
 from .inertia import change_inertia_reference_points_with_parallel_axis_theorem
 


### PR DESCRIPTION
## Summary

Fix W&B constraint violation logging so equality tolerances are assigned from each constraint row rather than from a zipped Lagrange-multiplier equality mask.

## Root Cause

`AugmentedLagrangianNonsmooth.is_equality()` is ordered by Lagrange multiplier, while `prog.GetAllConstraints()` is ordered by constraint object. A two-sided inequality contributes two inequality multiplier entries, so zipping constraints with `is_equality()` can shift later equality constraints onto `False` mask entries. In that case endpoint equalities are checked with the stricter inequality tolerance.

## Changes

- Iterate over constraints and constraint types only, tracking `lag_idx` separately for multiplier/residue indexing.
- Choose equality vs inequality tolerance from each constraint row's bounds (`lb == ub`).
- Add assertions to catch future metadata/order mismatches.
- Simplify constraint-type counter initialization.

## Validation

- `python3 -m py_compile robot_payload_id/optimization/nevergrad_augmented_lagrangian.py`

Full Drake runtime reproduction was not run in this scratch environment because `pydrake` is not installed.